### PR TITLE
Library upgrades including Spring Boot 3.1 support (#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ Json mystique ships a set of libraries written in and for Java, useful for json 
 * The library requires [Java 17+](https://www.oracle.com/java/technologies/downloads/#java17)
 * The library uses [maven](https://maven.apache.org/) for its build management
 * The library can be primarily used as a stand-alone java lib and depends on
-    * [Gson - 2.9.1](https://mvnrepository.com/artifact/com.google.code.gson/gson) for json String to Java pojo
+    * [Gson - 2.11.0](https://mvnrepository.com/artifact/com.google.code.gson/gson) for json String to Java pojo
       transformations
-    * [Jackson - 2.13.3](https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind) for json String
+    * [Jackson - 2.17.2](https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind) for json String
       to Java pojo transformations
 * For the [Spring](https://spring.io/) fan-boys, Json Mystique also ships a Spring-Starter, which depends on
-    * [Spring Boot - 2.7.3](https://docs.spring.io/spring-boot/docs/2.7.3/reference/htmlsingle/)
-    * [Spring-Framework - 5.3.22](https://docs.spring.io/spring-framework/docs/5.3.22/reference/html/) for IOC
+    * [Spring Boot - 3.3.2](https://docs.spring.io/spring-boot/3.3.2/index.html)
+    * [Spring-Framework - 6.1.11](https://docs.spring.io/spring-framework/docs/6.1.11/reference/html/) for IOC
 
 The actual versions can be found in the [pom file](/pom.xml)
 

--- a/json-mystique-boot/json-mystique-starter/src/main/resources/META-INF/spring.factories
+++ b/json-mystique-boot/json-mystique-starter/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.balajeetm.mystique.starter.GsonUtilAutoConfig,\
-com.balajeetm.mystique.starter.JacksonUtilAutoConfig,\
-com.balajeetm.mystique.starter.MystiqueAutoConfiguration

--- a/json-mystique-boot/json-mystique-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/json-mystique-boot/json-mystique-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,3 @@
+com.balajeetm.mystique.starter.GsonUtilAutoConfig
+com.balajeetm.mystique.starter.JacksonUtilAutoConfig
+com.balajeetm.mystique.starter.MystiqueAutoConfiguration

--- a/json-mystique-samples/mystique-web-sample/pom.xml
+++ b/json-mystique-samples/mystique-web-sample/pom.xml
@@ -14,14 +14,14 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.3</version>
+        <version>3.3.2</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <jsonmystique.version>2.5.3-SNAPSHOT</jsonmystique.version>
+        <jsonmystique.version>2.7.1-SNAPSHOT</jsonmystique.version>
     </properties>
 
     <dependencies>

--- a/json-mystique-samples/mystique-web-sample/src/main/java/com/balajeetm/mystique/samples/controller/SampleController.java
+++ b/json-mystique-samples/mystique-web-sample/src/main/java/com/balajeetm/mystique/samples/controller/SampleController.java
@@ -23,7 +23,7 @@ import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
@@ -54,7 +54,7 @@ public class SampleController {
   /** The rest template. */
   @Autowired RestTemplate restTemplate;
 
-  @Autowired @LocalServerPort String localPort;
+  @Autowired ServerProperties serverProperties;
 
   @Qualifier("jsonLever")
   @Autowired
@@ -110,7 +110,7 @@ public class SampleController {
             headers,
             HttpMethod.GET,
             URI.create(
-                String.format("http://localhost:%s/mystique/gson/serialise?msg=test", localPort)));
+                String.format("http://localhost:%s/mystique/gson/serialise?msg=test", serverProperties.getPort())));
     ResponseEntity<JsonElement> exchange = restTemplate.exchange(requestEntity, JsonElement.class);
     return exchange;
   }

--- a/json-mystique-samples/pom.xml
+++ b/json-mystique-samples/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.balajeetm.mystique</groupId>
         <artifactId>json-mystique-root</artifactId>
-        <version>2.5.3-SNAPSHOT</version>
+        <version>2.7.1-SNAPSHOT</version>
     </parent>
     <artifactId>json-mystique-samples</artifactId>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.3</version>
+        <version>3.3.2</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 
@@ -35,7 +35,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava-bom</artifactId>
-                <version>31.1-jre</version>
+                <version>33.2.1-jre</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -43,20 +43,20 @@
             <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
-                <version>2.9.1</version>
+                <version>2.11.0</version>
             </dependency>
 
             <!-- Apache -->
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.11.0</version>
+                <version>2.16.1</version>
             </dependency>
 
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.12.0</version>
+                <version>3.16.0</version>
             </dependency>
 
             <dependency>
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-            <version>1.2</version>
+            <version>1.3.3</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
I have gone through and updated the library to Spring Boot 3.1. While I was in there, I also bumped the version of the other libraries as well, and updated the versions and updated the sample libraries

- Spring Boot 3.1: From the Spring Documentation, the only  major breaking changes between Spring Boot 2.7 and 3.1 that I could find that applied to this library was the discontinuation of the spring.factories file in favor of the org.springframework.boot.autoconfigure.AutoConfiguration.imports file. I also discovered that the @LocalServerPort annotation was moved to the spring-boot-test package, and as such cant be used in a non-test class. I've corrected that in the sample application. No other breaking changes between Spring Boot 2.7 and 3.1, and Spring 5.X and 6.x apply to this library
- Guava 32.1.3: as per Google, Guava 32 is binary compatible with Guava 31
- Gson 2.10.1: Google's release notes listed no breaking changes
- CommonsIO 2.15.0: No breaking changes in Apache's release notes
- Commons Lang: No breaking changes in Apache's release notes
Jackson Databind 2.15.3: While there were some small behavioural changes, non appear to affect Mystique


All BDDs have been run and passed, and the Sample Application has been tested, and its Tests run and pass as well.